### PR TITLE
Feat : 인증 및 인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/be/auth/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/be/auth/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.be.auth.config;
+
+import com.example.be.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), errorCode.getMessage());
+        problemDetail.setTitle("Unauthorized");
+
+        response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+    }
+}

--- a/src/main/java/com/example/be/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/be/auth/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.example.be.auth.config;
+
+import com.example.be.auth.filter.JwtAuthenticationFilter;
+import com.example.be.auth.jwt.JwtTokenProvider;
+import com.example.be.auth.service.UserDetailsServiceImpl;
+import com.example.be.common.exception.ErrorCode;
+import com.example.be.common.exception.NotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@AllArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsServiceImpl;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((session)->session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsServiceImpl), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                )
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                        .anyRequest().authenticated())
+//                          .anyRequest().permitAll())
+        ;
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/example/be/auth/controller/AuthRestController.java
+++ b/src/main/java/com/example/be/auth/controller/AuthRestController.java
@@ -1,0 +1,60 @@
+package com.example.be.auth.controller;
+
+import com.example.be.auth.dto.LoginRequest;
+import com.example.be.auth.dto.LoginResponse;
+import com.example.be.auth.dto.RefreshRequest;
+import com.example.be.auth.dto.RegisterRequest;
+import com.example.be.auth.service.UserService;
+import com.example.be.common.annotation.ApiErrorCodeExamples;
+import com.example.be.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("api/v1/auth")
+@Tag(name = "인증/인가 기능", description = "회원 인증 및 인가 기능을 위한 api")
+public class AuthRestController {
+    private final UserService userService;
+
+    @Operation(summary = "회원 가입 기능",
+            description = "email, username, password를 입력받아 회원가입을 진행한다.",
+            security = @SecurityRequirement(name = "jwt 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK, ErrorCode.DUPLICATE_EMAIL, ErrorCode.DUPLICATE_USERNAME})
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody RegisterRequest registerRequest) {
+        userService.register(registerRequest);
+
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
+    }
+
+    @Operation(summary = "로그인 기능",
+            description = "email, password를 입력받아 로그인을 진행한다.",
+            security = @SecurityRequirement(name = "jwt 제외"))
+    @ApiResponse(responseCode = "200", description = "로그인 성공 시 access token 및 refresh token이 발급된다.")
+    @ApiErrorCodeExamples({ErrorCode.LOGIN_FAIL})
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(userService.login(loginRequest, request, response));
+    }
+
+    @Operation(summary = "refresh token 재발급 기능",
+            description = "refresh token을 입력받아 토큰을 재발급 받는다.",
+            security = @SecurityRequirement(name = "jwt 제외"))
+    @ApiResponse(responseCode = "200", description = "access token 및 refresh token이 발급된다.")
+    @ApiErrorCodeExamples({ErrorCode.INVALID_REFRESH_TOKEN})
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(@RequestBody RefreshRequest refreshRequest) {
+        return ResponseEntity.ok(userService.refresh(refreshRequest));
+    }
+}

--- a/src/main/java/com/example/be/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/be/auth/dto/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.example.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginRequest(@Schema(description = "사용자 이메일", example = "email1@gmail.com") String email,
+                           @Schema(description = "사용자 비밀 번호", example = "1234") String password) {
+}

--- a/src/main/java/com/example/be/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/be/auth/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.example.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(@Schema(description = "엑세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.asdoiqwdqs.sdqdeqdq") String accessToken,
+                            @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.asdoiqwdqs.sdqdeqdq") String refreshToken) {
+}

--- a/src/main/java/com/example/be/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/example/be/auth/dto/RefreshRequest.java
@@ -1,0 +1,6 @@
+package com.example.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RefreshRequest(@Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.asdoiqwdqs.sdqdeqdq") String refreshToken) {
+}

--- a/src/main/java/com/example/be/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/example/be/auth/dto/RegisterRequest.java
@@ -1,0 +1,8 @@
+package com.example.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegisterRequest(@Schema(description = "사용자 이메일", example = "email1@gmail.com") String email,
+                              @Schema(description = "사용자 이름", example = "무작위 이름 1") String username,
+                              @Schema(description = "사용자 비밀 번호", example = "1234") String password) {
+}

--- a/src/main/java/com/example/be/auth/entity/User.java
+++ b/src/main/java/com/example/be/auth/entity/User.java
@@ -1,0 +1,33 @@
+package com.example.be.auth.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(unique = true)
+    private String email;
+
+    @NotNull
+    @Column(unique = true)
+    private String username;
+
+    @NotNull
+    private String password;
+
+    public User(String email, String username, String password){
+        this.email = email;
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/be/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/be/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package com.example.be.auth.filter;
+
+import com.example.be.auth.jwt.JwtTokenProvider;
+import com.example.be.auth.service.UserDetailsServiceImpl;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@AllArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsServiceImpl;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        if(!(httpServletRequest.getHeader("Authorization") == null)) {
+            String token = jwtTokenProvider.resolveToken(httpServletRequest);
+
+            if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+                String email = jwtTokenProvider.getEmail(token);
+                UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(email);
+
+                if (userDetails != null) {
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/be/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,92 @@
+package com.example.be.auth.jwt;
+
+import com.example.be.auth.entity.User;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    @Value("${jwt.secret}")
+    private String secretKey;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final long ACCESS_FIVE_MINUTES = 1000L * 60;
+    private final long REFRESH_SEVEN_DAYS = 1000L * 60 * 60 * 24 * 7;
+
+    @PostConstruct
+    protected void init(){
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createAccessToken(User user){
+        Date now = new Date();
+
+        String token = Jwts.builder()
+                .setSubject(user.getEmail())
+                .claim("tokenType", "access")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_FIVE_MINUTES))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        return token;
+    }
+
+    public String createRefreshToken(User user){
+        Date now = new Date();
+
+        String refreshToken = Jwts.builder()
+                .setSubject(user.getEmail())
+                .claim("tokenType", "refresh")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_SEVEN_DAYS))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        redisTemplate.delete(user.getEmail());
+        redisTemplate.opsForHash().put(user.getEmail(), "refreshToken", refreshToken);
+        redisTemplate.opsForHash().put(user.getEmail(), "createdAt", String.valueOf(now.getTime()));
+
+        redisTemplate.expire(user.getEmail(), REFRESH_SEVEN_DAYS, TimeUnit.MILLISECONDS);
+
+        return refreshToken;
+    }
+
+    public String getEmail(String token){
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request){
+        return request.getHeader("Authorization").substring(7);
+    }
+
+    public boolean validateAccessToken(String accessToken){
+        try{
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(accessToken);
+            return !claims.getBody().getExpiration().before(new Date()) && !"access".equals(claims.getBody().get("tokenType", String.class));
+        }
+        catch(ExpiredJwtException e){
+            return false;
+        }
+    }
+
+    public boolean validateRefreshToken(String refreshToken){
+        try{
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(refreshToken);
+            return !claims.getBody().getExpiration().before(new Date()) && !"refresh".equals(claims.getBody().get("tokenType", String.class));
+        }
+        catch(ExpiredJwtException e){
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/be/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/be/auth/jwt/JwtTokenProvider.java
@@ -20,7 +20,7 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secretKey;
     private final RedisTemplate<String, String> redisTemplate;
-    private final long ACCESS_FIVE_MINUTES = 1000L * 60;
+    private final long ACCESS_FIVE_MINUTES = 1000L * 60 * 5;
     private final long REFRESH_SEVEN_DAYS = 1000L * 60 * 60 * 24 * 7;
 
     @PostConstruct

--- a/src/main/java/com/example/be/auth/repository/UserRepository.java
+++ b/src/main/java/com/example/be/auth/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.example.be.auth.repository;
+
+import com.example.be.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/example/be/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/example/be/auth/service/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package com.example.be.auth.service;
+
+import com.example.be.auth.entity.User;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private User user;
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // Role 관련 부분, 현재는 지정하지 않아서 따로 없음
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    public User getUser(){
+        return user;
+    }
+}

--- a/src/main/java/com/example/be/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/be/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.be.auth.service;
+
+import com.example.be.auth.entity.User;
+import com.example.be.auth.repository.UserRepository;
+import com.example.be.common.exception.BadRequestException;
+import com.example.be.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserDetailsServiceImpl implements UserDetailsService{
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Optional<User> userOptional = userRepository.findByEmail(email);
+        return userOptional.map(CustomUserDetails::new).orElseThrow(() -> new BadRequestException(ErrorCode.UNAUTHORIZED));
+    }
+}

--- a/src/main/java/com/example/be/auth/service/UserService.java
+++ b/src/main/java/com/example/be/auth/service/UserService.java
@@ -1,0 +1,86 @@
+package com.example.be.auth.service;
+
+import com.example.be.auth.dto.LoginRequest;
+import com.example.be.auth.dto.LoginResponse;
+import com.example.be.auth.dto.RefreshRequest;
+import com.example.be.auth.dto.RegisterRequest;
+import com.example.be.auth.entity.User;
+import com.example.be.auth.jwt.JwtTokenProvider;
+import com.example.be.auth.repository.UserRepository;
+import com.example.be.common.exception.BadRequestException;
+import com.example.be.common.exception.ConflictException;
+import com.example.be.common.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManager authenticationManager;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public void register(RegisterRequest registerRequest){
+        checkEmail(registerRequest.email());
+        checkUsername(registerRequest.username());
+
+        User user = new User(registerRequest.email(), registerRequest.username(), passwordEncoder.encode(registerRequest.password()));
+
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response){
+        try{
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password());
+
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            User user = userDetails.getUser();
+
+            return new LoginResponse(jwtTokenProvider.createAccessToken(user), jwtTokenProvider.createRefreshToken(user));
+        }
+        catch(BadCredentialsException e){
+            throw new ConflictException(ErrorCode.LOGIN_FAIL);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void checkEmail(String email) {
+        if (userRepository.existsByEmail(email)) throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkUsername(String username) {
+        if (userRepository.existsByUsername(username)) throw new ConflictException(ErrorCode.DUPLICATE_USERNAME);
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponse refresh(RefreshRequest refreshRequest){
+        if(jwtTokenProvider.validateRefreshToken(refreshRequest.refreshToken())){
+            String email = jwtTokenProvider.getEmail(refreshRequest.refreshToken());
+            String storedRefreshToken = (String) redisTemplate.opsForHash().get(email, "refreshToken");
+
+            if(storedRefreshToken.equals(refreshRequest.refreshToken())){
+                User user = userRepository.findByEmail(email).get();
+                return new LoginResponse(jwtTokenProvider.createAccessToken(user), jwtTokenProvider.createRefreshToken(user));
+            }
+        }
+        
+        throw new BadRequestException(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/example/be/common/annotation/ApiErrorCodeExample.java
+++ b/src/main/java/com/example/be/common/annotation/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package com.example.be.common.annotation;
+
+import com.example.be.common.exception.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorCode value();
+}

--- a/src/main/java/com/example/be/common/annotation/ApiErrorCodeExamples.java
+++ b/src/main/java/com/example/be/common/annotation/ApiErrorCodeExamples.java
@@ -1,0 +1,15 @@
+package com.example.be.common.annotation;
+
+import com.example.be.common.exception.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+
+    ErrorCode[] value();
+}

--- a/src/main/java/com/example/be/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/be/common/config/SwaggerConfig.java
@@ -1,10 +1,28 @@
 package com.example.be.common.config;
 
+import com.example.be.common.annotation.ApiErrorCodeExample;
+import com.example.be.common.annotation.ApiErrorCodeExamples;
+import com.example.be.common.exception.ErrorCode;
+import com.example.be.common.exception.ErrorResponseDto;
+import com.example.be.common.exception.ExampleHolder;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
@@ -21,5 +39,93 @@ public class SwaggerConfig {
                 .title("GDG-on-Campus-KNU Solution Challenge 8th team Backend API document")
                 .description("[Team Notion 바로가기](link)")
                 .version("0.0.1");
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(
+                    ApiErrorCodeExamples.class);
+
+            if (apiErrorCodeExamples != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExamples.value());
+            } else {
+                ApiErrorCodeExample apiErrorCodeExample = handlerMethod.getMethodAnnotation(
+                        ApiErrorCodeExample.class);
+
+                if (apiErrorCodeExample != null) {
+                    generateErrorCodeResponseExample(operation, apiErrorCodeExample.value());
+                }
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode[] errorCodes) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorCodes)
+                .map(
+                        errorCode -> ExampleHolder.builder()
+                                .holder(getSwaggerExample(errorCode))
+                                .code(errorCode.getHttpStatus().value())
+                                .name(errorCode.name())
+                                .build()
+                )
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode errorCode) {
+        ApiResponses responses = operation.getResponses();
+
+        ExampleHolder exampleHolder = ExampleHolder.builder()
+                .holder(getSwaggerExample(errorCode))
+                .name(errorCode.name())
+                .code(errorCode.getHttpStatus().value())
+                .build();
+        addExamplesToResponses(responses, exampleHolder);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(errorCode);
+        Example example = new Example();
+        example.setValue(errorResponseDto);
+
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+                                        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(),
+                                    exampleHolder.getHolder()
+                            )
+                    );
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(String.valueOf(status), apiResponse);
+                }
+        );
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+
+        mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
+        content.addMediaType("application/json", mediaType);
+        apiResponse.content(content);
+        responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
     }
 }

--- a/src/main/java/com/example/be/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/be/common/exception/ErrorCode.java
@@ -15,8 +15,10 @@ public enum ErrorCode {
 
     //Auth
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 있습니다."),
-    DUPLICATE_NICK_NAME(HttpStatus.CONFLICT, "중복된 닉네임이 있습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 시 입력한 정보가 틀렸거나, 로그인을 하지 않았습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "중복된 사용자명이 있습니다."),
+    LOGIN_FAIL(HttpStatus.CONFLICT, "로그인에 실패했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었거나 로그인을 하지 않았습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
 
     //Game
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "게임을 찾을 수 없습니다.")

--- a/src/main/java/com/example/be/common/exception/ErrorResponseDto.java
+++ b/src/main/java/com/example/be/common/exception/ErrorResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.be.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponseDto {
+    private String code;
+    private String message;
+
+    public ErrorResponseDto(ErrorCode errorCode) {
+        this.code = errorCode.getHttpStatus().toString();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/be/common/exception/ExampleHolder.java
+++ b/src/main/java/com/example/be/common/exception/ExampleHolder.java
@@ -1,0 +1,14 @@
+package com.example.be.common.exception;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #3

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

1. User 엔티티 생성, UserRepository 생성
2. 로그인, 회원가입 토큰 재발급 로직 서비스 레이어에 추가
- Spring Security 및 JWT 기반 로그인을 구현하였습니다.
- Access Token은 유효 시간 5분, Refresh Token은 7일로 지정하였습니다.
- 로그인 실패 시 409(Conflict)가 발생합니다.
- Access Token이 만료된 경우 401(Unauthorized)가 발생합니다.
- Refresh Token을 통해 토큰 재발급 실패 시 400(Bad Request)가 발생합니다. 
3. 컨트롤러 레이어에서 api 구현
4. Swagger를 통해 api 문서화
- 34.64.111.10:8080/swagger-ui/index.html에서 현재 구현되어 있는 api 목록을 확인할 수 있습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## ⏰ 현재 버그

## ✏ Git Close

> close #이슈번호
> #3 
