### PR TITLE
Feat : 마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/example/be/auth/controller/MyPageController.java
+++ b/src/main/java/com/example/be/auth/controller/MyPageController.java
@@ -1,0 +1,54 @@
+package com.example.be.auth.controller;
+
+import com.example.be.auth.dto.PasswordRequest;
+import com.example.be.auth.service.CustomUserDetails;
+import com.example.be.auth.service.MyPageService;
+import com.example.be.common.annotation.ApiErrorCodeExamples;
+import com.example.be.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("api/v1/mypage")
+@Tag(name = "마이페이지 기능", description = "비밀번호 변경, 로그아웃, 회원 탈퇴 기능을 포함한다.")
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @Operation(summary = "회원 탈퇴 기능",
+            description = "사용자의 정보를 제거하고 회원탈퇴를 수행한다.")
+    @ApiErrorCodeExamples({ErrorCode.UNAUTHORIZED})
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<?> deleteMember(@AuthenticationPrincipal CustomUserDetails userDetails){
+        myPageService.withdrawal(userDetails.getUser());
+
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
+    }
+
+    @Operation(summary = "로그아웃 기능",
+            description = "로그인한 사용자의 인증 권한을 제거한다.")
+    @ApiErrorCodeExamples({ErrorCode.UNAUTHORIZED})
+    @GetMapping("/logout")
+    public ResponseEntity<?> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        myPageService.logout(userDetails.getUser());
+
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
+    }
+
+    @Operation(summary = "비밀번호 변경 기능",
+            description = "로그인한 사용자의 비밀 번호를 변경한다.")
+    @ApiErrorCodeExamples({ErrorCode.UNAUTHORIZED})
+    @PutMapping("/password")
+    public ResponseEntity<?> changePassword(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                            @RequestBody PasswordRequest passwordRequest) {
+        myPageService.changePassword(userDetails.getUser(), passwordRequest);
+
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
+    }
+}

--- a/src/main/java/com/example/be/auth/controller/MyPageRestController.java
+++ b/src/main/java/com/example/be/auth/controller/MyPageRestController.java
@@ -7,8 +7,6 @@ import com.example.be.common.annotation.ApiErrorCodeExamples;
 import com.example.be.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @AllArgsConstructor
 @RequestMapping("api/v1/mypage")
 @Tag(name = "마이페이지 기능", description = "비밀번호 변경, 로그아웃, 회원 탈퇴 기능을 포함한다.")
-public class MyPageController {
+public class MyPageRestController {
     private final MyPageService myPageService;
 
     @Operation(summary = "회원 탈퇴 기능",

--- a/src/main/java/com/example/be/auth/entity/User.java
+++ b/src/main/java/com/example/be/auth/entity/User.java
@@ -30,4 +30,8 @@ public class User {
         this.username = username;
         this.password = password;
     }
+
+    public void update(String password){
+        this.password = password;
+    }
 }

--- a/src/main/java/com/example/be/auth/service/MyPageService.java
+++ b/src/main/java/com/example/be/auth/service/MyPageService.java
@@ -1,0 +1,36 @@
+package com.example.be.auth.service;
+
+import com.example.be.auth.dto.PasswordRequest;
+import com.example.be.auth.entity.User;
+import com.example.be.auth.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class MyPageService {
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void logout(User user){
+        redisTemplate.delete(user.getEmail());
+    }
+
+    @Transactional
+    public void withdrawal(User user){
+        logout(user);
+        userRepository.delete(user);
+    }
+
+    @Transactional
+    public void changePassword(User user, PasswordRequest passwordRequest){
+        user.update(passwordEncoder.encode(passwordRequest.password()));
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/be/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/be/common/config/SwaggerConfig.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,8 +31,17 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement)
                 .info(apiInfo());
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #5 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

1. 로그아웃 기능 구현
- redis에 저장된 refresh token을 삭제합니다. 프론트에서는 저장해둔 access Token 및 refresh Token 삭제하는 로직을 추가해주시면 됩니다.
2. 비밀번호 변경 기능 구현
- 로그인 후 비밀번호를 변경합니다.
3. 회원탈퇴 기능 구현
- 데이터베이스에 있는 회원 정보를 삭제합니다.
4. swagger에 jwt 토큰 추가 기능 삽입
![image](https://github.com/user-attachments/assets/0aa72b29-e9ff-48e9-815c-272c259e5b29)
- 오른쪽 위의 Authorize 버튼을 클릭합니다.
![image](https://github.com/user-attachments/assets/1dd37bea-65b6-43b6-85c2-44024df46c57)
- 빈 칸에 'Bearer {access Token}'을 추가한 후 authorize 버튼을 클릭하면 요청 시 헤더에 'Authorization : Bearer {access Token}'이 추가됩니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## ⏰ 현재 버그

## ✏ Git Close

> close #5
> 
