### PR TITLE
Feat : 구글 소셜 로그인 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,4 +61,6 @@ jobs:
               -e SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }} \
               -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
               -e GCP_URL=${{ secrets.GCP_URL }} \
+              -e GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }} \
+              -e GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }} \
               ${{ secrets.DOCKER_HUB_USERNAME }}/gdg-8th-sc:latest

--- a/src/main/java/com/example/be/auth/controller/AuthRestController.java
+++ b/src/main/java/com/example/be/auth/controller/AuthRestController.java
@@ -1,9 +1,6 @@
 package com.example.be.auth.controller;
 
-import com.example.be.auth.dto.LoginRequest;
-import com.example.be.auth.dto.LoginResponse;
-import com.example.be.auth.dto.RefreshRequest;
-import com.example.be.auth.dto.RegisterRequest;
+import com.example.be.auth.dto.*;
 import com.example.be.auth.service.UserService;
 import com.example.be.common.annotation.ApiErrorCodeExamples;
 import com.example.be.common.exception.ErrorCode;
@@ -14,11 +11,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @AllArgsConstructor
 @RestController
@@ -56,5 +55,26 @@ public class AuthRestController {
     @PostMapping("/refresh")
     public ResponseEntity<LoginResponse> refresh(@RequestBody RefreshRequest refreshRequest) {
         return ResponseEntity.ok(userService.refresh(refreshRequest));
+    }
+
+    @Operation(summary = "구글 로그인을 통한 코드 요청",
+            description = "구글 서버로부터 로그인을 하여 code를 발급받는다.(리다이렉트 형태)",
+            security = @SecurityRequirement(name = "jwt 제외"))
+    @ApiResponse(responseCode = "200", description = "code가 발급된다.")
+    @GetMapping("/google-code")
+    public ResponseEntity<?> getGoogleLoginURI(HttpServletRequest request) throws URISyntaxException {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setLocation(new URI(userService.getGoogleLoginURI(request)));
+        return new ResponseEntity<>(httpHeaders, HttpStatus.PERMANENT_REDIRECT);
+    }
+
+    @Operation(summary = "구글 로그인",
+            description = "구글 서버로부터 받은 코드를 입력값으로 넣어 백엔드 서버에 로그인을 진행한다.",
+            security = @SecurityRequirement(name = "jwt 제외"))
+    @ApiResponse(responseCode = "200", description = "access token 및 refresh token이 발급된다.")
+    @ApiErrorCodeExamples({ErrorCode.LOGIN_FAIL})
+    @PostMapping("/google-login")
+    public ResponseEntity<LoginResponse> googleLogin(@RequestBody GoogleLoginRequest googleLoginRequest, HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(userService.googleLogin(googleLoginRequest.code(), request));
     }
 }

--- a/src/main/java/com/example/be/auth/dto/GoogleAccessTokenRequest.java
+++ b/src/main/java/com/example/be/auth/dto/GoogleAccessTokenRequest.java
@@ -1,0 +1,8 @@
+package com.example.be.auth.dto;
+
+public record GoogleAccessTokenRequest(String code,
+                                       String client_id,
+                                       String client_secret,
+                                       String redirect_uri,
+                                       String grant_type) {
+}

--- a/src/main/java/com/example/be/auth/dto/GoogleAccessTokenResponse.java
+++ b/src/main/java/com/example/be/auth/dto/GoogleAccessTokenResponse.java
@@ -1,0 +1,8 @@
+package com.example.be.auth.dto;
+
+public record GoogleAccessTokenResponse(String access_token,
+                                        String expires_in,
+                                        String scope,
+                                        String token_type,
+                                        String id_token) {
+}

--- a/src/main/java/com/example/be/auth/dto/GoogleAccountProfileResponse.java
+++ b/src/main/java/com/example/be/auth/dto/GoogleAccountProfileResponse.java
@@ -1,0 +1,11 @@
+package com.example.be.auth.dto;
+
+public record GoogleAccountProfileResponse(String id,
+                                           String email,
+                                           String verified_email,
+                                           String name,
+                                           String given_name,
+                                           String family_name,
+                                           String picture,
+                                           String locale) {
+}

--- a/src/main/java/com/example/be/auth/dto/GoogleLoginRequest.java
+++ b/src/main/java/com/example/be/auth/dto/GoogleLoginRequest.java
@@ -1,0 +1,6 @@
+package com.example.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GoogleLoginRequest(@Schema(description = "구글로부터 받은 code", example = "4%2F0AfJohXlpgkCgIruONFGdaZ9NBbqWY77MkcJlPLFJg9NQmB38ZFpy80qUjKCFOWWSRIGevA") String code) {
+}

--- a/src/main/java/com/example/be/auth/properties/GoogleLoginProperties.java
+++ b/src/main/java/com/example/be/auth/properties/GoogleLoginProperties.java
@@ -1,0 +1,20 @@
+package com.example.be.auth.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "oauth2.client.registration.google")
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class GoogleLoginProperties {
+    private String clientId;
+    private String clientSecret;
+    private String scope;
+    private String tokenURI;
+    private String profileURI;
+}

--- a/src/main/java/com/example/be/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/be/common/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.be.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,9 @@ spring.mail.username=${SMTP_USERNAME}
 spring.mail.password=${SMTP_PASSWORD}
 #jwt
 jwt.secret=${JWT_SECRET}
+#google_login
+oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+oauth2.client.registration.google.scope=email%20profile
+oauth2.client.registration.google.token-uri=https://oauth2.googleapis.com/token
+oauth2.client.registration.google.profile-uri=https://www.googleapis.com/userinfo/v2/me


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #12 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

- 구글 소셜 로그인 기능 구현
1. /api/v1/auth/google-code api를 통해 구글 로그인을 진행합니다.
2. 그 후 리다이렉트 형태로 {요청 주소}/login/oauth2/code/google?code={실제 코드} 처럼 쿼리 파라미터 형태로 code를 전달받습니다.
3. 전달받은 code를 /api/v1/auth/google-login 의 requestBody에 추가합니다.
4. response로 accessToken 및 refreshToken을 전달받습니다.
- deploy.yml에 환경 변수 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ⏰ 현재 버그

## ✏ Git Close

> close #12 
> 
